### PR TITLE
Merge mossample changes into master

### DIFF
--- a/WDmodel/fit.py
+++ b/WDmodel/fit.py
@@ -655,7 +655,6 @@ def fit_model(spec, phot, model, covmodel, pbs, params,\
             if (i > 0) & (i%100 == 0):
                 outf.flush()
             bar.show(i+1)
-        bar.done()
 
     # save the acceptance fraction
     chain.create_dataset("afrac", data=sampler.acceptance_fraction)

--- a/WDmodel/fit.py
+++ b/WDmodel/fit.py
@@ -661,9 +661,10 @@ def fit_model(spec, phot, model, covmodel, pbs, params,\
 
         # save the chain
         samples = sampler.flatchain
+        samples = samples.reshape(ntemps*nwalkers*nprod, nparam)
         dset_chain  = chain.create_dataset("position",data=samples)
         lnprob = sampler.lnprobability
-        lnprob = lnprob.reshape(ntemps*nwalkers,nprod)
+        lnprob = lnprob.reshape(ntemps*nwalkers*nprod)
         dset_lnprob = chain.create_dataset("lnprob",data=lnprob)
 
     # save the acceptance fraction

--- a/WDmodel/io.py
+++ b/WDmodel/io.py
@@ -510,12 +510,15 @@ def read_mcmc(input_file):
         chain_params   = {}
         samples        = d['chain']['position'].value
         samples_lnprob = d['chain']['lnprob'].value
-        chain_params['param_names']   = d['chain']['names'].value
-        chain_params['nwalkers']      = d['chain'].attrs['nwalkers']
-        chain_params['nprod']        = d['chain'].attrs['nprod']
-        chain_params['ndim']          = d['chain'].attrs['nparam']
-        chain_params['everyn']        = d['chain'].attrs['everyn']
-        chain_params['ascale']        = d['chain'].attrs['ascale']
+        chain_params['param_names'] = d['chain']['names'].value
+        chain_params['samptype']    = d['chain'].attrs['samptype']
+        chain_params['ntemps']      = d['chain'].attrs['ntemps']
+        chain_params['nwalkers']    = d['chain'].attrs['nwalkers']
+        chain_params['nprod']       = d['chain'].attrs['nprod']
+        chain_params['ndim']        = d['chain'].attrs['nparam']
+        chain_params['everyn']      = d['chain'].attrs['everyn']
+        chain_params['ascale']      = d['chain'].attrs['ascale']
+
 
     except KeyError as e:
         message = '{}\nCould not load all arrays from input file {}'.format(e, input_file)

--- a/WDmodel/io.py
+++ b/WDmodel/io.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 import warnings
 from copy import deepcopy
 import numpy as np
@@ -282,12 +281,7 @@ def make_outdirs(dirname, redo=False):
     """
     if os.path.isdir(dirname):
         if redo:
-            try:
-                print "--redo specified. REMOVING EXISTING DIRECTORY {} !".format(dirname)
-                shutil.rmtree(dirname)
-            except (OSError, IOError) as e:
-                message = "{}\nOutput directory {} already exists and cannot clobber!".format(e, dirname)
-                raise IOError(message)
+            return
         else:
             message = "Output directory {} already exists. Specify --redo to clobber.".format(dirname)
             raise IOError(message)

--- a/WDmodel/mossampler.py
+++ b/WDmodel/mossampler.py
@@ -1,0 +1,265 @@
+"""Overridden PTSampler with random Gibbs selection, more-reliable acor."""
+import numpy as np
+from emcee.autocorr import AutocorrError, function
+from emcee.ptsampler import PTLikePrior, PTSampler
+
+
+class MOSSampler(PTSampler):
+    """Override PTSampler methods."""
+
+    def get_autocorr_time(
+            self, min_step=0, max_walkers=-1, chain=[], **kwargs):
+        """Return a matrix of autocorrelation lengths.
+
+        Returns a matrix of autocorrelation lengths for each
+        parameter in each temperature of shape ``(Ntemps, Ndim)``.
+        Any arguments will be passed to :func:`autocorr.integrate_time`.
+        """
+        acors = np.zeros((self.ntemps, self.dim))
+
+        for i in range(self.ntemps):
+            acors[i, :] = 0.0
+            if len(chain):
+                x = chain[i, :max_walkers, min_step:, :]
+            else:
+                x = self._chain[i, :max_walkers, min_step:, :]
+            for w in x:
+                acors[i, :] += self.integrated_time(w, **kwargs)
+            acors[i, :] /= len(x)
+        return acors
+
+    def integrated_time(
+        self, x, low=10, high=None, step=1, c=5, full_output=False,
+            axis=0, fast=False):
+        """Estimate the integrated autocorrelation time of a time series.
+
+        This estimate uses the iterative procedure described on page 16 of
+        `Sokal's notes <http://www.stat.unc.edu/faculty/cji/Sokal.pdf>`_ to
+        determine a reasonable window size.
+
+        Args:
+            x: The time series. If multidimensional, set the time axis using
+                the ``axis`` keyword argument and the function will be
+                computed for every other axis.
+            low (Optional[int]): The minimum window size to test. (default:
+                ``10``)
+            high (Optional[int]): The maximum window size to test. (default:
+                ``x.shape[axis] / (2*c)``)
+            step (Optional[int]): The step size for the window search.
+                (default: ``1``)
+            c (Optional[float]): The minimum number of autocorrelation times
+                needed to trust the estimate. (default: ``10``)
+            full_output (Optional[bool]): Return the final window size as well
+                as the autocorrelation time. (default: ``False``)
+            axis (Optional[int]): The time axis of ``x``. Assumed to be the
+                first axis if not specified.
+            fast (Optional[bool]): If ``True``, only use the first ``2^n`` (for
+                the largest power) entries for efficiency. (default: False)
+
+        Returns:
+            float or array: An estimate of the integrated autocorrelation time
+                of the time series ``x`` computed along the axis ``axis``.
+            Optional[int]: The final window size that was used. Only returned
+                if ``full_output`` is ``True``.
+
+        Raises
+            AutocorrError: If the autocorrelation time can't be reliably
+                estimated from the chain. This normally means that the chain
+                is too short.
+
+        """
+        size = 0.5 * x.shape[axis]
+        if int(c * low) >= size:
+            raise AutocorrError("The chain is too short")
+
+        # Compute the autocorrelation function.
+        f = function(x, axis=axis, fast=fast)
+
+        # Check the dimensions of the array.
+        oned = len(f.shape) == 1
+        m = [slice(None), ] * len(f.shape)
+
+        # Loop over proposed window sizes until convergence is reached.
+        if high is None:
+            high = int(size / c)
+        for M in np.arange(low, high, step).astype(int):
+            # Compute the autocorrelation time with the given window.
+            if oned:
+                # Special case 1D for simplicity.
+                tau = 1 + 2 * np.sum(f[1:M])
+            else:
+                # N-dimensional case.
+                m[axis] = slice(1, M)
+                tau = 1 + 2 * np.sum(f[m], axis=axis)
+
+            # Accept the window size if it satisfies the convergence criterion.
+            if np.all(tau > 1.0) and M > c * tau.max():
+                if full_output:
+                    return tau, M
+                return tau
+
+            # If the autocorrelation time is too long to be estimated reliably
+            # from the chain, it should fail.
+            if c * tau.max() >= size:
+                break
+
+        raise AutocorrError("The chain is too short to reliably estimate "
+                            "the autocorrelation time")
+
+    def sample(
+        self, p0, lnprob0=None, lnlike0=None, iterations=1,
+            thin=1, storechain=True, gibbs=False):
+        """Advance the chains ``iterations`` steps as a generator.
+
+        :param p0:
+            The initial positions of the walkers.  Shape should be
+            ``(ntemps, nwalkers, dim)``.
+        :param lnprob0: (optional)
+            The initial posterior values for the ensembles.  Shape
+            ``(ntemps, nwalkers)``.
+        :param lnlike0: (optional)
+            The initial likelihood values for the ensembles.  Shape
+            ``(ntemps, nwalkers)``.
+        :param iterations: (optional)
+            The number of iterations to preform.
+        :param thin: (optional)
+            The number of iterations to perform between saving the
+            state to the internal chain.
+        :param storechain: (optional)
+            If ``True`` store the iterations in the ``chain``
+            property.
+        At each iteration, this generator yields
+        * ``p``, the current position of the walkers.
+        * ``lnprob`` the current posterior values for the walkers.
+        * ``lnlike`` the current likelihood values for the walkers.
+        """
+        if not gibbs:
+            for n in super(MOSSampler, self).sample(
+                    p0, lnprob0, lnlike0, iterations, thin, storechain):
+                yield n
+            return
+
+        p = np.copy(np.array(p0))
+
+        # If we have no lnprob or logls compute them
+        if lnprob0 is None or lnlike0 is None:
+            fn = PTLikePrior(self.logl, self.logp, self.loglargs,
+                             self.logpargs, self.loglkwargs, self.logpkwargs)
+            if self.pool is None:
+                results = list(map(fn, p.reshape((-1, self.dim))))
+            else:
+                results = list(self.pool.map(fn, p.reshape((-1, self.dim))))
+
+            logls = np.array([r[0] for r in results]).reshape((self.ntemps,
+                                                               self.nwalkers))
+            logps = np.array([r[1] for r in results]).reshape((self.ntemps,
+                                                               self.nwalkers))
+
+            lnlike0 = logls
+            lnprob0 = logls * self.betas.reshape((self.ntemps, 1)) + logps
+
+        lnprob = lnprob0
+        logl = lnlike0
+
+        # Expand the chain in advance of the iterations
+        if storechain:
+            nsave = iterations // thin
+            if self._chain is None:
+                isave = 0
+                self._chain = np.zeros((self.ntemps, self.nwalkers, nsave,
+                                        self.dim))
+                self._lnprob = np.zeros((self.ntemps, self.nwalkers, nsave))
+                self._lnlikelihood = np.zeros((self.ntemps, self.nwalkers,
+                                               nsave))
+            else:
+                isave = self._chain.shape[2]
+                self._chain = np.concatenate((self._chain,
+                                              np.zeros((self.ntemps,
+                                                        self.nwalkers,
+                                                        nsave, self.dim))),
+                                             axis=2)
+                self._lnprob = np.concatenate((self._lnprob,
+                                               np.zeros((self.ntemps,
+                                                         self.nwalkers,
+                                                         nsave))),
+                                              axis=2)
+                self._lnlikelihood = np.concatenate((self._lnlikelihood,
+                                                     np.zeros((self.ntemps,
+                                                               self.nwalkers,
+                                                               nsave))),
+                                                    axis=2)
+
+        for i in range(iterations):
+            thawed = np.array(sorted(np.random.choice(
+                self.dim, np.random.randint(1, self.dim), replace=False)))
+            for j in [0, 1]:
+                jupdate = j
+                jsample = (j + 1) % 2
+
+                pupdate = p[:, jupdate::2, :]
+                psample = p[:, jsample::2, :]
+
+                zs = np.exp(np.random.uniform(
+                    low=-np.log(self.a), high=np.log(self.a),
+                    size=(self.ntemps, self.nwalkers // 2)))
+
+                qs = np.zeros((self.ntemps, self.nwalkers // 2, self.dim))
+                for k in range(self.ntemps):
+                    js = np.random.randint(0, high=self.nwalkers // 2,
+                                           size=self.nwalkers // 2)
+                    yrange = np.arange(self.nwalkers // 2).reshape(-1, 1)
+                    qs[k, :, :] = psample[k, :, :]
+                    qs[k, yrange,
+                       thawed] = psample[
+                        k, js.reshape(-1, 1), thawed] + zs[k, :].reshape(
+                            (self.nwalkers // 2, 1)) * (
+                                pupdate[k, yrange, thawed] -
+                                psample[k, js.reshape(-1, 1), thawed])
+
+                fn = PTLikePrior(self.logl, self.logp, self.loglargs,
+                                 self.logpargs, self.loglkwargs,
+                                 self.logpkwargs)
+                if self.pool is None:
+                    results = list(map(fn, qs.reshape((-1, self.dim))))
+                else:
+                    results = list(self.pool.map(fn, qs.reshape((-1,
+                                                                 self.dim))))
+
+                qslogls = np.array([r[0] for r in results]).reshape(
+                    (self.ntemps, self.nwalkers // 2))
+                qslogps = np.array([r[1] for r in results]).reshape(
+                    (self.ntemps, self.nwalkers // 2))
+                qslnprob = qslogls * self.betas.reshape((self.ntemps, 1)) \
+                    + qslogps
+
+                logpaccept = self.dim * np.log(zs) + qslnprob \
+                    - lnprob[:, jupdate::2]
+                logrs = np.log(np.random.uniform(low=0.0, high=1.0,
+                                                 size=(self.ntemps,
+                                                       self.nwalkers // 2)))
+
+                accepts = logrs < logpaccept
+                accepts = accepts.flatten()
+
+                pupdate.reshape((-1, self.dim))[accepts, :] = \
+                    qs.reshape((-1, self.dim))[accepts, :]
+                lnprob[:, jupdate::2].reshape((-1,))[accepts] = \
+                    qslnprob.reshape((-1,))[accepts]
+                logl[:, jupdate::2].reshape((-1,))[accepts] = \
+                    qslogls.reshape((-1,))[accepts]
+
+                accepts = accepts.reshape((self.ntemps, self.nwalkers // 2))
+
+                self.nprop[:, jupdate::2] += 1.0
+                self.nprop_accepted[:, jupdate::2] += accepts
+
+            p, lnprob, logl = self._temperature_swaps(p, lnprob, logl)
+
+            if (i + 1) % thin == 0:
+                if storechain:
+                    self._chain[:, :, isave, :] = p
+                    self._lnprob[:, :, isave, ] = lnprob
+                    self._lnlikelihood[:, :, isave] = logl
+                    isave += 1
+
+            yield p, lnprob, logl

--- a/WDmodel/viz.py
+++ b/WDmodel/viz.py
@@ -195,7 +195,7 @@ def plot_mcmc_spectrum_fit(spec, objname, specfile, scale_factor, model, covmode
                 marker=None, alpha=0.3, color='orange')
 
     if everyn != 1:
-        ax_spec.plot(spec.wave[::everyn], (smoothedmod+wres)[::everyn], color='blue', marker='o', ls='None',\
+        ax_spec.plot(spec.wave[::everyn], spec.flux[::everyn], color='blue', marker='o', ls='None',\
             alpha=0.5, label='everyn:{:n}'.format(everyn))
         ax_resid.plot(spec.wave[::everyn], (spec.flux-smoothedmod-wres)[::everyn], color='blue', marker='o',\
                 alpha=0.5, ls='None')
@@ -326,7 +326,7 @@ def plot_mcmc_spectrum_nogp_fit(spec, objname, specfile, scale_factor,\
 
     if everyn != 1:
         smoothedmod, wres, _, _, _ = draws[-1]
-        ax_spec.plot(spec.wave[::everyn], smoothedmod[::everyn], color='blue', marker='o', ls='None',\
+        ax_spec.plot(spec.wave[::everyn], spec.flux[::everyn], color='blue', marker='o', ls='None',\
                 alpha=0.5, label='everyn:{:n}'.format(everyn))
         ax_resid.plot(spec.wave[::everyn], wres[::everyn], marker='o',  color='blue', ls='None', alpha=0.5)
 

--- a/WDmodel/viz.py
+++ b/WDmodel/viz.py
@@ -113,7 +113,7 @@ def plot_minuit_spectrum_fit(spec, objname, outdir, specfile, scale_factor, mode
 
 
 def plot_mcmc_spectrum_fit(spec, objname, specfile, scale_factor, model, covmodel, result, param_names, samples,\
-        rvmodel='od94', ndraws=21):
+        rvmodel='od94', ndraws=21, everyn=1):
     """
     Plot the full spectrum of the DA White Dwarf
     """
@@ -189,9 +189,17 @@ def plot_mcmc_spectrum_fit(spec, objname, specfile, scale_factor, model, covmode
     ax_resid.fill_between(spec.wave, spec.flux-smoothedmod-wres+spec.flux_err, spec.flux-smoothedmod-wres-spec.flux_err,\
         facecolor='grey', alpha=0.5, interpolate=True)
     ax_resid.plot(spec.wave, spec.flux-smoothedmod-wres,  linestyle='-', marker=None,  color='black')
+
     for draw in out[:-1]:
         ax_resid.plot(spec.wave, draw[0]+draw[1]-smoothedmod-wres, linestyle='-',\
                 marker=None, alpha=0.3, color='orange')
+
+    if everyn != 1:
+        ax_spec.plot(spec.wave[::everyn], (smoothedmod+wres)[::everyn], color='blue', marker='o', ls='None',\
+            alpha=0.5, label='everyn:{:n}'.format(everyn))
+        ax_resid.plot(spec.wave[::everyn], (spec.flux-smoothedmod-wres)[::everyn], color='blue', marker='o',\
+                alpha=0.5, ls='None')
+
     ax_resid.axhline(0., color='red', linestyle='--')
     ax_resid.fill_between(spec.wave, +wres_err, -wres_err,\
         facecolor='red', alpha=0.3, interpolate=True)
@@ -275,7 +283,8 @@ def plot_mcmc_photometry_res(objname, phot, phot_dispersion, model, pbs, draws):
     return fig, mag_draws
 
 
-def plot_mcmc_spectrum_nogp_fit(spec, objname, specfile, scale_factor, cont_model, draws, covtype='ExpSquared'):
+def plot_mcmc_spectrum_nogp_fit(spec, objname, specfile, scale_factor,\
+        cont_model, draws, covtype='ExpSquared', everyn=1):
     """
     Plot the full spectrum of the DA White Dwarf
     """
@@ -314,6 +323,12 @@ def plot_mcmc_spectrum_nogp_fit(spec, objname, specfile, scale_factor, cont_mode
     for draw in draws[:-1]:
         plot_draw(draw, color='orange', alpha=0.3)
     plot_draw(draws[-1], color='red', alpha=1.0, label='Model - no Covariance')
+
+    if everyn != 1:
+        smoothedmod, wres, _, _, _ = draws[-1]
+        ax_spec.plot(spec.wave[::everyn], smoothedmod[::everyn], color='blue', marker='o', ls='None',\
+                alpha=0.5, label='everyn:{:n}'.format(everyn))
+        ax_resid.plot(spec.wave[::everyn], wres[::everyn], marker='o',  color='blue', ls='None', alpha=0.5)
 
     # label the axes
     ax_resid.set_xlabel('Wavelength~(\AA)',fontproperties=font_m, ha='center')
@@ -459,7 +474,7 @@ def plot_mcmc_model(spec, phot, linedata, scale_factor, phot_dispersion,\
         objname, outdir, specfile,\
         model, covmodel, cont_model, pbs,\
         params, param_names, samples, samples_lnprob,\
-        covtype='White', rvmodel='od94', balmer=None, save=True, ndraws=21, savefig=False):
+        covtype='White', rvmodel='od94', balmer=None, save=True, ndraws=21, everyn=1, savefig=False):
     """
     Plot the full fit of the DA White Dwarf
     """
@@ -472,13 +487,12 @@ def plot_mcmc_model(spec, phot, linedata, scale_factor, phot_dispersion,\
         # plot spectrum and model
         fig, draws  =  plot_mcmc_spectrum_fit(spec, objname, specfile, scale_factor,\
                 model, covmodel, params, param_names, samples,\
-                rvmodel=rvmodel, ndraws=ndraws)
+                rvmodel=rvmodel, ndraws=ndraws, everyn=everyn)
         if savefig:
             outfile = io.get_outfile(outdir, specfile, '_mcmc_spectrum.pdf')
             fig.savefig(outfile)
         pdf.savefig(fig)
 
-        # TODO - extinction law plot?
         # plot the photometry and residuals if we actually fit it, else skip
         if phot is not None:
             fig, mag_draws = plot_mcmc_photometry_res(objname, phot, phot_dispersion, model, pbs, draws)
@@ -488,7 +502,8 @@ def plot_mcmc_model(spec, phot, linedata, scale_factor, phot_dispersion,\
             pdf.savefig(fig)
 
         # plot continuum, model and draws without gp
-        fig = plot_mcmc_spectrum_nogp_fit(spec, objname, specfile, scale_factor, cont_model, draws, covtype=covtype)
+        fig = plot_mcmc_spectrum_nogp_fit(spec, objname, specfile, scale_factor,\
+                cont_model, draws, covtype=covtype, everyn=everyn)
         if savefig:
             outfile = io.get_outfile(outdir, specfile, '_mcmc_nogp.pdf')
             fig.savefig(outfile)

--- a/fit_WDmodel.py
+++ b/fit_WDmodel.py
@@ -293,7 +293,7 @@ def main(inargs=None, pool=None):
 
 
     # set the object name and create output directories
-    objname, outdir = WDmodel.io.set_objname_outdir_for_specfile(specfile, outdir=outdir, outroot=outroot)
+    objname, outdir = WDmodel.io.set_objname_outdir_for_specfile(specfile, outdir=outdir, outroot=outroot, redo=redo)
     print "Writing to outdir {}".format(outdir)
 
     # parse the parameter keywords in the argparse Namespace into a dictionary

--- a/fit_WDmodel.py
+++ b/fit_WDmodel.py
@@ -420,7 +420,8 @@ def main(inargs=None, pool=None):
                     objname, outdir, specfile,\
                     model, covmodel, cont_model, pbs,\
                     mcmc_params, param_names, in_samp, in_lnprob,\
-                    covtype=covtype, rvmodel=rvmodel, balmer=balmer, ndraws=ndraws, savefig=savefig)
+                    covtype=covtype, rvmodel=rvmodel, balmer=balmer,\
+                    ndraws=ndraws, everyn=everyn, savefig=savefig)
         model_spec, full_mod, model_mags = plot_out
 
         spec_model_file = WDmodel.io.get_outfile(outdir, specfile, '_spec_model.dat')

--- a/fit_WDmodel.py
+++ b/fit_WDmodel.py
@@ -122,18 +122,24 @@ def get_options(args=None):
     mcmc = parser.add_argument_group('mcmc', 'MCMC options')
     mcmc.add_argument('--skipminuit',  required=False, action="store_true", default=False,\
             help="Skip Minuit fit - make sure to specify dl guess")
+    mcmc.add_argument('--samptype', required=False, default='ensemble', choices=('ensemble', 'gibbs', 'pt'),\
+            help='Specify what kind of sampler you want to use')
     mcmc.add_argument('--skipmcmc',  required=False, action="store_true", default=False,\
             help="Skip MCMC - if you skip both minuit and MCMC, simply prepares files")
     mcmc.add_argument('--ascale', required=False, type=float, default=2.0,\
             help="Specify proposal scale for MCMC")
     mcmc.add_argument('--nwalkers',  required=False, type=int, default=300,\
             help="Specify number of walkers to use (0 disables MCMC)")
+    mcmc.add_argument('--ntemps', required=False, type=int, default=1,\
+            help="Specify number of temperatures in ladder for parallel tempering - only available with PTSampler")
     mcmc.add_argument('--nburnin',  required=False, type=int, default=200,\
             help="Specify number of steps for burn-in")
     mcmc.add_argument('--nprod',  required=False, type=int, default=2000,\
             help="Specify number of steps for production")
     mcmc.add_argument('--everyn',  required=False, type=int, default=1,\
             help="Use only every nth point in data for computing likelihood - useful for testing.")
+    mcmc.add_argument('--thin', required=False, type=int, default=1,\
+            help="Save only every nth point in the chain - only works with PTSampler and Gibbs")
     mcmc.add_argument('--discard',  required=False, type=float, default=5,\
             help="Specify percentage of steps to be discarded")
 
@@ -191,6 +197,14 @@ def get_options(args=None):
         message = 'Number of walkers must be even ({})'.format(args.nwalkers)
         raise ValueError(message)
 
+    if args.ntemps <= 0:
+        message = 'Number of temperatures must be greater than zero ({})'.format(args.ntemps)
+        raise ValueError(message)
+
+    if (args.ntemps > 1) and (args.samptype == 'ensemble'):
+        message = 'Multiple temperatures only available with PTSampler or Gibbs Sampler: ({})'.format(args.ntemps)
+        raise ValueError(message)
+
     if args.nburnin <= 0:
         message = 'Number of burnin steps must be greater than zero ({})'.format(args.nburnin)
         raise ValueError(message)
@@ -205,6 +219,14 @@ def get_options(args=None):
 
     if args.everyn < 1:
         message = 'EveryN must be integer GE 1. Note that 1 does nothing. ({:g})'.format(args.everyn)
+        raise ValueError(message)
+
+    if args.thin < 1:
+        message = 'Thin must be integer GE 1. Note that 1 does nothing. ({:g})'.format(args.thin)
+        raise ValueError(message)
+
+    if (args.thin > 1) and (args.samptype == 'ensemble'):
+        message = 'Chain thinning only available with PTSampler or Gibbs Sampler: ({})'.format(args.thin)
         raise ValueError(message)
 
     return args
@@ -250,11 +272,14 @@ def main(inargs=None, pool=None):
     tol       = args.hodlr_tol
     nleaf     = args.hodlr_nleaf
 
+    samptype  = args.samptype
     ascale    = args.ascale
+    ntemps    = args.ntemps
     nwalkers  = args.nwalkers
     nburnin   = args.nburnin
     nprod     = args.nprod
     everyn    = args.everyn
+    thin      = args.thin
     redo      = args.redo
 
     discard   = args.discard
@@ -371,7 +396,9 @@ def main(inargs=None, pool=None):
         result = WDmodel.fit.fit_model(spec, phot, model, covmodel, pbs, migrad_params,\
                     objname, outdir, specfile,\
                     rvmodel=rvmodel, phot_dispersion=phot_dispersion,\
-                    ascale=ascale, nwalkers=nwalkers, nburnin=nburnin, nprod=nprod, everyn=everyn,\
+                    samptype=samptype, ascale=ascale,\
+                    ntemps=ntemps, nwalkers=nwalkers, nburnin=nburnin, nprod=nprod,\
+                    thin=thin, everyn=everyn,\
                     redo=redo,\
                     pool=pool)
 
@@ -380,7 +407,7 @@ def main(inargs=None, pool=None):
 
         # parse the samples in the chain and get the result
         result = WDmodel.fit.get_fit_params_from_samples(param_names, samples, samples_lnprob, mcmc_params,\
-                        nwalkers=nwalkers, nprod=nprod, discard=discard)
+                        ntemps=ntemps, nwalkers=nwalkers, nprod=nprod, discard=discard)
         mcmc_params, in_samp, in_lnprob = result
 
         # write the result to a file


### PR DESCRIPTION
Adds support for PTSampler and gibbs sampler from @guillochon. Alll chains, including EnsembleSampler, have shape (ntemps, nwalkers, nprod, ndim) for consistency. They are stored flattened along with the flattened (ntemps, nwalkers, npod) log posterior. The chain is now saved periodically (but the rstate isn't - fix @gnarayan) and few other cosmetic updates from testing. 