### PR TITLE
Fix issue #13: State reset after burn-in

### DIFF
--- a/WDmodel/fit.py
+++ b/WDmodel/fit.py
@@ -878,8 +878,6 @@ def fit_model(spec, phot, model, covmodel, pbs, params,\
 
         # set walkers to start production at final burnin state
         pos = result[0]
-        if samptype != 'ensemble':
-            pos = pos.reshape(ntemps, nwalkers, nparam)
 
         # setup incremental chain saving
         chain = outf.create_group("chain")

--- a/WDmodel/fit.py
+++ b/WDmodel/fit.py
@@ -876,9 +876,8 @@ def fit_model(spec, phot, model, covmodel, pbs, params,\
             message = "{} = {:f}".format(k,v)
             print(message)
 
-        # adjust the walkers to start around the MAP position from burnin
-        pos = emcee.utils.sample_ball(p1, std, size=ntemps*nwalkers)
-        pos = fix_pos(pos, free_param_names, params)
+        # set walkers to start production at final burnin state
+        pos = result[0]
         if samptype != 'ensemble':
             pos = pos.reshape(ntemps, nwalkers, nparam)
 


### PR DESCRIPTION
Minimal changes to address gnarayan#13.  The MAP parameters no longer have to be computed after burn-in, so those lines could be removed, too, but keeping them isn't a problem other than a bit of a speed hit.